### PR TITLE
Add a note on Fedora 23 Xorg bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Fedora Prime
 
 A collection of shell scripts that makes it possible to use the NVIDIA GPU on a Optimus Laptop. The switching
 is similar to the feature provided by the nvidia-prime package in Ubuntu. However, no such package has been
-made for other distributions. This is exactly the functionality this package provide. 
+made for other distributions. This is exactly the functionality this package provide.
 
 Background
 ----------
@@ -14,7 +14,7 @@ both documentation for developers of the nouveau project (an open-source impleme
 and partially support for switching between the Intel and NVIDIA drivers. Canonical then began working on their
 nvidia-prime package that should make the switching simple, basically just providing one command `prime-select`
 for switching, taking either `nvidia` or `intel` as parameter. The downside is that you need to logout for the
-switching to happen. The same limitations are there for this package. 
+switching to happen. The same limitations are there for this package.
 
 Features
 --------
@@ -34,7 +34,7 @@ kernel module is compiled. Backup the following files (will be deleted by fedora
 
 Install the RPM package, use my COPR repository
 
-    # dnf copr enable bosim/fedora-prime 
+    # dnf copr enable bosim/fedora-prime
     # dnf install fedora-prime-select
 
 Edit `/etc/fedora-prime/xorg.nvidia.conf` and add the right `BusID` (mine was `4:0:0`, yours is probably something
@@ -51,6 +51,15 @@ Author
 Known bugs
 ----------
 
+* If you are using Fedora 23 with `xorg-x11-server` version `1.18.0-2.fc23` there is [known bug](https://bugs.freedesktop.org/show_bug.cgi?id=92313) which result in corrupted menus and undetectable screen resolution in `nvidia-settings`. Temporay workaround is to downgrade `xorg-x11-server` package to the one from Fedora 22 repository:
+```sh
+# downgrade package(s):
+dnf --allowerasing --releasever=22 downgrade xorg-x11-server-Xorg
+# prevent upgrade for xorg-x11* stack:
+echo 'exclude=xorg-x11*' >> /etc/dnf/dnf.conf
+```
+**Note:** remember to remove restriction and do a system update when the fix will be available.
+
 * If you are in Intel mode and your system has been suspended, changing to NVIDIA may result in blank screen. Therefore
 you may need to reboot your machine. This is due to limitations of gdm (Ubuntu has patched gdm to run a script similar to
 `xinitrc.nvidia`, but these changes are not available upstream, thanks Ubuntu). We set the intel card active during reboot,
@@ -60,4 +69,3 @@ TODO
 ----
 
 * BusID detection for `xorg.nvidia.conf`
-

--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Known bugs
 ----------
 
 * If you are using Fedora 23 with `xorg-x11-server` version `1.18.0-2.fc23` there is [known bug](https://bugs.freedesktop.org/show_bug.cgi?id=92313) which result in corrupted menus and undetectable screen resolution in `nvidia-settings`. Temporay workaround is to downgrade `xorg-x11-server` package to the one from Fedora 22 repository:
-```sh
-# downgrade package(s):
-dnf --allowerasing --releasever=22 downgrade xorg-x11-server-Xorg
-# prevent upgrade for xorg-x11* stack:
-echo 'exclude=xorg-x11*' >> /etc/dnf/dnf.conf
-```
+  ```sh
+  # downgrade package(s):
+  dnf --allowerasing --releasever=22 downgrade xorg-x11-server-Xorg
+  # prevent upgrade for xorg-x11* stack:
+  echo 'exclude=xorg-x11*' >> /etc/dnf/dnf.conf
+  ```
 **Note:** remember to remove restriction and do a system update when the fix will be available.
 
 * If you are in Intel mode and your system has been suspended, changing to NVIDIA may result in blank screen. Therefore


### PR DESCRIPTION
There is a [bug](https://bugs.freedesktop.org/show_bug.cgi?id=92313) in current Xorg server package for Fedora 23, which results in broken menus placement for many applications and broken resolution detected in `nvidia-settings`. Downgrading helps. Added to known bugs section.
