### PR TITLE
add basic busid detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,3 @@ Known bugs
 you may need to reboot your machine. This is due to limitations of gdm (Ubuntu has patched gdm to run a script similar to
 `xinitrc.nvidia`, but these changes are not available upstream, thanks Ubuntu). We set the intel card active during reboot,
 so we should always be able to recover from the blackscreen by rebooting.
-
-TODO
-----
-
-* BusID detection for `xorg.nvidia.conf`

--- a/README.md
+++ b/README.md
@@ -44,8 +44,7 @@ Install the RPM package, use my COPR repository
     # dnf copr enable bosim/fedora-prime
     # dnf install fedora-prime-select
 
-Edit `/etc/fedora-prime/xorg.nvidia.conf` and add the right `BusID` (mine was `4:0:0`, yours is probably something
-else. Find it using `lspci`). Restart. When you login you can run `fedora-prime-select nvidia` and then logout/login
+Restart. When you login you can run `fedora-prime-select nvidia` and then logout/login
 and you will be using the NVIDIA GPU. Since the way of switching GPU does not play well with GDM we will use the
 Intel GPU are every reboot.
 

--- a/fedora-prime-select
+++ b/fedora-prime-select
@@ -35,7 +35,8 @@ case $1 in
   nvidia )
     printf "Switching to %s..." "$1"
     clean_files
-    ln -s $install_dir/xorg.conf /etc/X11/xorg.conf
+    bus_id=$(lspci | grep NVIDIA | awk '{print $1 + 0}')
+    sed "s/bus_id/$bus_id/g" $install_dir/xorg.conf.template > /etc/X11/xorg.conf
     ln -s $install_dir/xinitrc.nvidia /etc/X11/xinit/xinitrc.d/nvidia
     echo '/usr/lib64/nvidia' > $nvidia64_lib_file
     if [[ -f $nvidia32_lib_file ]]; then

--- a/fedora-prime-select
+++ b/fedora-prime-select
@@ -28,6 +28,8 @@ clean_files() {
 }
 
 install_dir='/etc/fedora-prime'
+nvidia32_lib_file='/etc/ld.so.conf.d/nvidia-lib.conf'
+nvidia64_lib_file='/etc/ld.so.conf.d/nvidia-lib64.conf'
 
 case $1 in
   nvidia )
@@ -35,17 +37,17 @@ case $1 in
     clean_files
     ln -s $install_dir/xorg.conf /etc/X11/xorg.conf
     ln -s $install_dir/xinitrc.nvidia /etc/X11/xinit/xinitrc.d/nvidia
-    echo '/usr/lib64/nvidia' > /etc/ld.so.conf.d/nvidia-lib64.conf
-    if [[ -f /etc/ld.so.conf.d/nvidia-lib.conf ]]; then
-      echo '/usr/lib/nvidia' > /etc/ld.so.conf.d/nvidia-lib.conf
+    echo '/usr/lib64/nvidia' > $nvidia64_lib_file
+    if [[ -f $nvidia32_lib_file ]]; then
+      echo '/usr/lib/nvidia' > $nvidia32_lib_file
     fi
     ;;
   intel )
     printf "Switching to %s..." "$1"
     clean_files
-    echo '/usr/lib64' > /etc/ld.so.conf.d/nvidia-lib64.conf
-    if [[ -f /etc/ld.so.conf.d/nvidia-lib.conf ]]; then
-      echo '# disabled by fedora-prime' > /etc/ld.so.conf.d/nvidia-lib.conf
+    echo '/usr/lib64' > $nvidia64_lib_file
+    if [[ -f $nvidia32_lib_file ]]; then
+      echo '# disabled by fedora-prime' > $nvidia32_lib_file
     fi
     ;;
   * )

--- a/fedora-prime.spec
+++ b/fedora-prime.spec
@@ -23,7 +23,7 @@ This is exactly the functionality this package provide.
 
 %install
 mkdir -p %{buildroot}%{fedora_prime_dir}
-install -p -m 0644 xorg.conf %{buildroot}%{fedora_prime_dir}/
+install -p -m 0644 xorg.conf.template %{buildroot}%{fedora_prime_dir}/
 install -p -m 0755 xinitrc.nvidia %{buildroot}%{fedora_prime_dir}/
 
 mkdir -p %{buildroot}%{_sbindir}
@@ -41,7 +41,7 @@ systemctl disable fedora-prime.service
 %files
 %doc README.md LICENSE
 %{fedora_prime_dir}/xinitrc.nvidia
-%{fedora_prime_dir}/xorg.conf
+%{fedora_prime_dir}/xorg.conf.template
 %{_sbindir}/fedora-prime-select
 %{_unitdir}/fedora-prime.service
 

--- a/xorg.conf.template
+++ b/xorg.conf.template
@@ -17,7 +17,7 @@ EndSection
 Section "Device"
     Identifier "nvidia"
     Driver "nvidia"
-    BusID "PCI:4:0:0"
+    BusID "PCI:bus_id:0:0"
     Option "DPI" "96 x 96"
 EndSection
 


### PR DESCRIPTION
Not sure if the best method, but a quick googling shows that all nvidia bus id's are in format of "bus_id:0:0". I was not using nvidia-settings, since it is failing to launch for me in intel mode.
