### PR TITLE
Fix 'unterminated s' error for sed command

### DIFF
--- a/fedora-prime-select
+++ b/fedora-prime-select
@@ -35,7 +35,7 @@ case $1 in
   nvidia )
     clean_files
     bus_id=$(lspci | grep NVIDIA | awk '{print $1 + 0}')
-    sed "s/bus_id/$bus_id/g" $install_dir/xorg.conf.template > /etc/X11/xorg.conf
+    sed 's/bus_id/${bus_id}/g' $install_dir/xorg.conf.template > /etc/X11/xorg.conf
     ln -s $install_dir/xinitrc.nvidia /etc/X11/xinit/xinitrc.d/nvidia
     printf '/usr/lib64/nvidia' > $nvidia64_lib_file
     if [[ -f $nvidia32_lib_file ]]; then


### PR DESCRIPTION
In Fedora 35 there was an unterminated s command error when running the "sudo fedora-prime-selector nvidia" command. It's fixed with these updates.